### PR TITLE
Initial chat history handling from backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -156,6 +156,15 @@ class MerchantInfo(BaseModel):
     language: str
 
 
+# ID should be UUID v4
+# timestamps are Unix timestamp
+class Chat(BaseModel):
+    id: str
+    title: str
+    preview: str
+    timestamp: int
+
+
 def process_csv_row(row: dict, config: CSVConfig) -> Document:
     """Convert a CSV row into a Document"""
     # Combine specified text columns
@@ -320,10 +329,50 @@ async def chat_to_llm(
     file: Annotated[UploadFile, File()]
 ):
     # Send data to LLM for processing
+    # Save chat to database
     return {
         "response": "Womp Womp",
         "image_URL": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fpadoru.wiki%2Fimages%2Fpadoru.png&f=1&nofb=1&ipt=a7cff58e3937272582c2417e06a3dd748494dd39be4a5678c62df4687eb1c3c8"
     }
+
+
+@app.get("/get_all_chats")
+async def get_all_chats() -> list[Chat]:
+    # Read database for list of chats
+    # Note that messages are NOT part of this data
+    # should compare to another database table with the matching chat ID
+    return [
+        Chat(
+            id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            title="Customer Engagement Strategies",
+            preview="Let's discuss ways to improve your customer retention rates.",
+            timestamp=1713542400
+        ),
+        Chat(
+            id="38d28c87-5e13-4bd5-a3ba-e88f87e7838c",
+            title="Inventory Management",
+            preview="I've analyzed your stock patterns and identified optimization opportunities.",
+            timestamp=1713543600
+        ),
+        Chat(
+            id="b0e46453-7184-41e5-b14b-9f5a9d29b456",
+            title="Marketing Campaign Review",
+            preview="How can we adjust your social media advertising to increase conversions?",
+            timestamp=1713545400
+        ),
+        Chat(
+            id="65a7c97d-f239-4c5d-89cc-5a37f5b1cdf3",
+            title="Sales Analytics Report",
+            preview="Your Q1 numbers show interesting patterns in customer buying habits.",
+            timestamp=1713549000
+        ),
+        Chat(
+            id="c29143a3-e83d-48e5-ac8a-f51277cf72ea",
+            title="E-commerce Platform Upgrade",
+            preview="I recommend these improvements to your online checkout process.",
+            timestamp=1713552600
+        )
+    ]
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -165,6 +165,16 @@ class Chat(BaseModel):
     timestamp: int
 
 
+# id and chat_id should be UUID v4
+# sender is either 'user' or 'bot'
+# timestamps are Unix timestamp
+class Message(BaseModel):
+    id: str
+    text: str
+    sender: str
+    timestamp: int
+
+
 def process_csv_row(row: dict, config: CSVConfig) -> Document:
     """Convert a CSV row into a Document"""
     # Combine specified text columns
@@ -371,6 +381,43 @@ async def get_all_chats() -> list[Chat]:
             title="E-commerce Platform Upgrade",
             preview="I recommend these improvements to your online checkout process.",
             timestamp=1713552600
+        )
+    ]
+
+
+@app.get("/get_all_messages")
+async def get_messages(chat_id: str):
+    # Return all messages under the specific chat
+    return [
+        Message(
+            id="8f7d1a6e-9c5a-4b3d-8a7e-2e8d79c10e44",
+            text="Womp womp... our sales are down 15% this quarter.",
+            sender="user",
+            timestamp=1713542400
+        ),
+        Message(
+            id="3e7c8945-f2a1-4d6b-ba3c-d98e1c045f22",
+            text="Don't worry! Every womp womp moment is an opportunity for improvement. Let's analyze what happened.",
+            sender="bot",
+            timestamp=1713542460
+        ),
+        Message(
+            id="b23d8f7a-4c5e-4a9b-8d3f-e2c7a1b9d634",
+            text="Womp womp wooooomp. Our biggest competitor just launched a huge promotion.",
+            sender="user",
+            timestamp=1713542520
+        ),
+        Message(
+            id="7a1b4d6e-2c5f-4e8d-9a3b-6c7e5d8f9a1b",
+            text="I see the womp womp situation, but this gives us a chance to differentiate. What unique value can you offer?",
+            sender="bot",
+            timestamp=1713542580
+        ),
+        Message(
+            id="5e9d2c1b-7a3f-4e8d-9c5b-2a4f7e3d8c1a",
+            text="*sad trombone* Womp womp... Our marketing budget is already maxed out.",
+            sender="user",
+            timestamp=1713542640
         )
     ]
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "react-leaflet": "^5.0.0",
         "react-router": "^7.5.0",
         "react-router-dom": "^7.5.0",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -6417,6 +6418,19 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
     "react-leaflet": "^5.0.0",
     "react-router": "^7.5.0",
     "react-router-dom": "^7.5.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -158,11 +158,15 @@ export default function Chatbot() {
   // Update your loadChat function to reset the new chat state
   const loadChat = (chatId) => {
     setIsNewChat(false);
-    const chat = chatHistory.find(c => c.id === chatId);
-    if (chat) {
-      setCurrentChatMessages(chat.messages);
-      setCurrentChatId(chatId);
-    }
+    fetch(import.meta.env.BACKEND_URL + "/get_all_messages" +
+      new URLSearchParams({ chat_id: chatId }).toString()
+    )
+      .then(response => response.json())
+      .then(responseData => {
+        setCurrentChatMessages(prev => [ ...prev, ...responseData])
+      });
+
+    setCurrentChatId(chatId);
   };
 
   // Update your handleSubmit function to reset isNewChat when saving

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -109,6 +109,18 @@ export default function Chatbot() {
     scrollToBottom();
   }, [currentChatMessages, loading]);
 
+  // Get all chats from user
+  useEffect(() => {
+    let ignore = false;
+    fetch(import.meta.env.BACKEND_URL + "/get_all_chats")
+    .then(response => response.json())
+    .then(responseData => {
+        setChatList(responseData)
+      });
+
+    return () => { ignore = true };
+  }, [])
+
   useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {
@@ -188,7 +200,7 @@ export default function Chatbot() {
         setLoading(false);
 
         if (!currentChatId) {
-          saveChatToHistory();
+          saveUserChat();
           setIsNewChat(false); // Reset new chat state after saving
         }
       });
@@ -206,7 +218,7 @@ export default function Chatbot() {
     return date.toLocaleDateString();
   };
 
-  const saveChatToHistory = () => {
+  const saveUserChat = () => {
     if (currentChatMessages.length <= 1) return;
 
     const newChat = {

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -23,6 +23,8 @@ import {
 import jsConvert from 'js-convert-case';
 import { v4 as uuidV4 } from 'uuid';
 
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+
 // Component
 export default function Chatbot() {
   // State Management
@@ -112,10 +114,13 @@ export default function Chatbot() {
   // Get all chats from user
   useEffect(() => {
     let ignore = false;
-    fetch(import.meta.env.BACKEND_URL + "/get_all_chats")
-    .then(response => response.json())
-    .then(responseData => {
-        setChatList(responseData)
+    fetch(BACKEND_URL + "/get_all_chats")
+      .then(response => response.json())
+      .then(responseData => {
+        setChatList(responseData);
+      })
+      .catch(err => {
+        console.log(err);
       });
 
     return () => { ignore = true };
@@ -158,7 +163,7 @@ export default function Chatbot() {
   // Update your loadChat function to reset the new chat state
   const loadChat = (chatId) => {
     setIsNewChat(false);
-    fetch(import.meta.env.BACKEND_URL + "/get_all_messages" +
+    fetch(BACKEND_URL + "/get_all_messages" +
       new URLSearchParams({ chat_id: chatId }).toString()
     )
       .then(response => response.json())
@@ -192,7 +197,7 @@ export default function Chatbot() {
     payload.append("chat_id", currentChatId);
     payload.append("file", fileInputRef.current.files[0])
 
-    fetch(import.meta.env.BACKEND_URL + "/send_chat", {
+    fetch(BACKEND_URL + "/send_chat", {
       method: "POST",
       body: payload
     })
@@ -260,7 +265,7 @@ export default function Chatbot() {
   };
 
   const handleMerchantProfileSave = (e) => {
-    fetch(import.meta.env.BACKEND_URL + "/update_merchant_info", {
+    fetch(BACKEND_URL + "/update_merchant_info", {
       method: PUT,
       body: JSON.stringify(
         jsConvert.snakeKeys(merchantProfile)
@@ -372,7 +377,12 @@ export default function Chatbot() {
                 >
                   <div className="font-medium text-gray-900 truncate">{chat.title}</div>
                   <div className="text-sm text-gray-500 truncate">{chat.preview}</div>
-                  <div className="text-xs text-gray-400 mt-1">{formatDate(chat.timestamp)}</div>
+                  <div className="text-xs text-gray-400 mt-1">{
+                    // Date() accepts Unix timestamp in milliseconds, so need to convert first
+                    formatDate(
+                      new Date(chat.timestamp * 1000)
+                    )
+                  }</div>
                 </button>
               ))}
             </>

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -233,6 +233,10 @@ export default function Chatbot() {
     return date.toLocaleDateString();
   };
 
+  // Convert Unix timestamps to Date objects
+  // Note that Date accepts timestamp in millisecond instead of seconds
+  const timestampToDate = (timestamp) => new Date(timestamp * 1000);
+
   const saveUserChat = () => {
     if (currentChatMessages.length <= 1) return;
 
@@ -383,12 +387,7 @@ export default function Chatbot() {
                 >
                   <div className="font-medium text-gray-900 truncate">{chat.title}</div>
                   <div className="text-sm text-gray-500 truncate">{chat.preview}</div>
-                  <div className="text-xs text-gray-400 mt-1">{
-                    // Date() accepts Unix timestamp in milliseconds, so need to convert first
-                    formatDate(
-                      new Date(chat.timestamp * 1000)
-                    )
-                  }</div>
+                  <div className="text-xs text-gray-400 mt-1">{formatDate( timestampToDate(chat.timestamp) )}</div>
                 </button>
               ))}
             </>
@@ -516,7 +515,7 @@ export default function Chatbot() {
                             </div>
                           )}
                         <div className="text-xs text-gray-500 mt-1">
-                          {msg.timestamp.toLocaleTimeString([], {
+                          {timestampToDate(msg.timestamp).toLocaleTimeString([], {
                             hour: '2-digit',
                             minute: '2-digit',
                           })}

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -162,10 +162,16 @@ export default function Chatbot() {
 
   // Update your loadChat function to reset the new chat state
   const loadChat = (chatId) => {
+    if (chatId == currentChatId)
+      return
+
     setIsNewChat(false);
-    fetch(BACKEND_URL + "/get_all_messages" +
-      new URLSearchParams({ chat_id: chatId }).toString()
-    )
+    setCurrentChatMessages([]);
+
+    let getAllMessagesAPI = new URL(BACKEND_URL + "/get_all_messages");
+    getAllMessagesAPI.searchParams.append("chat_id", chatId);
+
+    fetch(getAllMessagesAPI.toString())
       .then(response => response.json())
       .then(responseData => {
         setCurrentChatMessages(prev => [ ...prev, ...responseData])

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -95,7 +95,7 @@ export default function Chatbot() {
   ];
 
   // State Management
-  const [messages, setMessages] = useState([
+  const [currentChatMessages, setCurrentChatMessages] = useState([
     {
       id: '1',
       text: 'Hello! I am your HEX assistant. I can help you with questions, writing, analysis, and more. How can I assist you today?',
@@ -176,7 +176,7 @@ export default function Chatbot() {
     };
 
     scrollToBottom();
-  }, [messages, loading]);
+  }, [currentChatMessages, loading]);
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -192,15 +192,15 @@ export default function Chatbot() {
         prev.map((chat) =>
           chat.id === currentChatId ? {
             ...chat,
-            messages,
-            title: messages.find(m => m.sender === 'user')?.text.substring(0, 30) || chat.title,
-            preview: messages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
+            messages: currentChatMessages,
+            title: currentChatMessages.find(m => m.sender === 'user')?.text.substring(0, 30) || chat.title,
+            preview: currentChatMessages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
             timestamp: new Date()
           } : chat
         )
       );
     }
-  }, [messages, currentChatId]);
+  }, [currentChatMessages, currentChatId]);
 
   // Handlers
   // Removed duplicate loadChat function
@@ -208,7 +208,7 @@ export default function Chatbot() {
   // Update your newChat function to set this state
   const newChat = () => {
     setIsNewChat(true);
-    setMessages([
+    setCurrentChatMessages([
       {
         id: '1',
         text: 'Hello! I am your HEX assistant. I can help you with questions, writing, analysis, and more. How can I assist you today?',
@@ -227,7 +227,7 @@ export default function Chatbot() {
     setIsNewChat(false);
     const chat = chatHistory.find(c => c.id === chatId);
     if (chat) {
-      setMessages(chat.messages);
+      setCurrentChatMessages(chat.messages);
       setCurrentChatId(chatId);
     }
   };
@@ -245,7 +245,7 @@ export default function Chatbot() {
       mode: activeMode,
     };
 
-    setMessages(prev => [...prev, userMsg]);
+    setCurrentChatMessages(prev => [...prev, userMsg]);
     setInput('');
     setLoading(true);
 
@@ -263,7 +263,7 @@ export default function Chatbot() {
       .then(responseData => {
         const botMsg = responseData.response;
 
-        setMessages(prev => [...prev, botMsg]);
+        setCurrentChatMessages(prev => [...prev, botMsg]);
         setLoading(false);
 
         if (!currentChatId) {
@@ -300,14 +300,14 @@ export default function Chatbot() {
   };
 
   const saveChatToHistory = () => {
-    if (messages.length <= 1) return;
+    if (currentChatMessages.length <= 1) return;
 
     const newChat = {
       id: `chat${Date.now()}`,
-      title: messages.find(m => m.sender === 'user')?.text.substring(0, 30) || 'New Chat',
-      preview: messages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
+      title: currentChatMessages.find(m => m.sender === 'user')?.text.substring(0, 30) || 'New Chat',
+      preview: currentChatMessages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
       timestamp: new Date(),
-      messages: [...messages]
+      messages: [...currentChatMessages]
     };
 
     setChatHistory(prev => [newChat, ...prev]);
@@ -503,10 +503,10 @@ export default function Chatbot() {
         {/* Chat Area */}
         <div className="flex-1 overflow-y-auto bg-gray-50">
           <div className="max-w-3xl mx-auto w-full p-4">
-            {messages.length === 0 ? (
+            {currentChatMessages.length === 0 ? (
               renderExamplePrompts()
             ) : (
-                messages.map((msg) => (
+                currentChatMessages.map((msg) => (
                   <div
                     key={msg.id}
                     className={`mb-6 last:mb-0 ${msg.sender === 'bot' ? 'pr-8' : 'pl-8'

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -21,6 +21,7 @@ import {
   Languages
 } from 'lucide-react';
 import jsConvert from 'js-convert-case';
+import { v4 as uuidV4 } from 'uuid';
 
 // Component
 export default function Chatbot() {
@@ -238,7 +239,7 @@ export default function Chatbot() {
     if (!input.trim() || loading) return;
 
     const userMsg = {
-      id: Date.now().toString(),
+      id: uuidV4(),
       text: input,
       sender: 'user',
       timestamp: new Date(),
@@ -303,7 +304,7 @@ export default function Chatbot() {
     if (currentChatMessages.length <= 1) return;
 
     const newChat = {
-      id: `chat${Date.now()}`,
+      id: `chat-${uuidV4()}`,
       title: currentChatMessages.find(m => m.sender === 'user')?.text.substring(0, 30) || 'New Chat',
       preview: currentChatMessages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
       timestamp: new Date(),

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -25,76 +25,6 @@ import { v4 as uuidV4 } from 'uuid';
 
 // Component
 export default function Chatbot() {
-  // Sample chat history data
-  const sampleChatHistory = [
-    {
-      id: 'chat1',
-      title: 'Marketing Strategy',
-      preview: 'Let me analyze our competitors...',
-      timestamp: new Date(Date.now() - 86400000), // Yesterday
-      messages: [
-        {
-          id: '1',
-          text: 'Can you analyze our competitors in the food delivery market?',
-          sender: 'user',
-          timestamp: new Date(Date.now() - 86400000),
-        },
-        {
-          id: '2',
-          text: 'After analyzing competitors: 1. Competitor A has 40% market share 2. Competitor B focuses on premium restaurants 3. Competitor C has fastest delivery times',
-          sender: 'bot',
-          timestamp: new Date(Date.now() - 86300000),
-          mode: 'deep-think'
-        }
-      ]
-    },
-    {
-      id: 'chat2',
-      title: 'Image Generation',
-      preview: 'Restaurant menu design...',
-      timestamp: new Date(Date.now() - 3600000), // 1 hour ago
-      messages: [
-        {
-          id: '1',
-          text: 'Generate an image of a modern restaurant menu',
-          sender: 'user',
-          timestamp: new Date(Date.now() - 3600000),
-          mode: 'image'
-        },
-        {
-          id: '2',
-          text: 'Here\'s the generated image of a modern restaurant menu',
-          sender: 'bot',
-          timestamp: new Date(Date.now() - 3590000),
-          isImage: true,
-          imageUrl: 'https://source.unsplash.com/random/800x400/?restaurant,menu'
-        }
-      ]
-    },
-    {
-      id: 'chat3',
-      title: 'Market Research',
-      preview: 'Latest food trends...',
-      timestamp: new Date(Date.now() - 1800000), // 30 minutes ago
-      messages: [
-        {
-          id: '1',
-          text: 'Search for latest food trends in Southeast Asia',
-          sender: 'user',
-          timestamp: new Date(Date.now() - 1800000),
-          mode: 'search'
-        },
-        {
-          id: '2',
-          text: 'Search results for food trends:\n1. Plant-based meats growing 30% YoY\n2. Cloud kitchens expanding\n3. Ghost kitchens gaining popularity',
-          sender: 'bot',
-          timestamp: new Date(Date.now() - 1790000),
-          mode: 'search'
-        }
-      ]
-    }
-  ];
-
   // State Management
   const [currentChatMessages, setCurrentChatMessages] = useState([
     {
@@ -111,7 +41,7 @@ export default function Chatbot() {
   const [isRecording, setIsRecording] = useState(false);
   const [recognition, setRecognition] = useState(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [chatHistory, setChatHistory] = useState(sampleChatHistory);
+  const [chatList, setChatList] = useState([]);
   const [isNewChat, setIsNewChat] = useState(false); // Add this line
   const [currentChatId, setCurrentChatId] = useState(null);
   const [examplePrompts, setExamplePrompts] = useState([
@@ -189,19 +119,9 @@ export default function Chatbot() {
 
   useEffect(() => {
     if (currentChatId) {
-      setChatHistory((prev) =>
-        prev.map((chat) =>
-          chat.id === currentChatId ? {
-            ...chat,
-            messages: currentChatMessages,
-            title: currentChatMessages.find(m => m.sender === 'user')?.text.substring(0, 30) || chat.title,
-            preview: currentChatMessages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
-            timestamp: new Date()
-          } : chat
-        )
-      );
+      // Fetch current chat data if currentChatId changes
     }
-  }, [currentChatMessages, currentChatId]);
+  }, [currentChatId]);
 
   // Handlers
   // Removed duplicate loadChat function
@@ -270,20 +190,6 @@ export default function Chatbot() {
         if (!currentChatId) {
           saveChatToHistory();
           setIsNewChat(false); // Reset new chat state after saving
-        } else {
-          setChatHistory(prev =>
-            prev.map(chat =>
-              chat.id === currentChatId
-                ? {
-                  ...chat,
-                  messages: [...chat.messages, userMsg, botMsg],
-                  title: userMsg.text.substring(0, 30) || chat.title,
-                  preview: botMsg.text.substring(0, 50) || 'New conversation',
-                  timestamp: new Date()
-                }
-                : chat
-            )
-          );
         }
       });
   };
@@ -308,10 +214,9 @@ export default function Chatbot() {
       title: currentChatMessages.find(m => m.sender === 'user')?.text.substring(0, 30) || 'New Chat',
       preview: currentChatMessages.find(m => m.sender === 'bot')?.text.substring(0, 50) || 'New conversation',
       timestamp: new Date(),
-      messages: [...currentChatMessages]
     };
 
-    setChatHistory(prev => [newChat, ...prev]);
+    setChatList(prev => [newChat, ...prev]);
     setCurrentChatId(newChat.id);
   };
 
@@ -440,9 +345,9 @@ export default function Chatbot() {
             </button>
           )}
 
-          {chatHistory.length > 0 ? (
+          {chatList.length > 0 ? (
             <>
-              {chatHistory.map((chat) => (
+              {chatList.map((chat) => (
                 <button
                   key={chat.id}
                   onClick={() => loadChat(chat.id)}

--- a/frontend/src/components/Chatbot.jsx
+++ b/frontend/src/components/Chatbot.jsx
@@ -468,8 +468,7 @@ export default function Chatbot() {
                           )}
                       </div>
                       <div
-                        className={`max-w-[calc(100%-56px)] ${msg.sender === 'bot' ? 'text-left' : 'text-right'
-}`}
+                        className="max-w-[calc(100%-56px)]"
                       >
                         {msg.mode && msg.sender === 'user' && (
                           <div className="text-xs text-gray-500 mb-1">


### PR DESCRIPTION
- Removed mock chat history
- Separated messages data from chat data (for easy use on database later)
- API routes to get messages and chat list of a user (`get_all_messages` and `get_all_chats`)
- Conversion from Unix timestamp to Date object
- Fixed bug on failing API calls (Vite will only accept environment variables with `VITE_` prefix)
- Fixed text positioning of the chats

Note that we need two tables now, one for chat list, and one for message list. Also timestamp will be stored and sent as Unix timestamps in seconds.